### PR TITLE
Extend reading with delay and retry.

### DIFF
--- a/Sources/Socket/SocketProtocols.swift
+++ b/Sources/Socket/SocketProtocols.swift
@@ -30,27 +30,36 @@ public protocol SocketReader {
 	///
 	/// Reads a string.
 	///
+	/// In order to deal with slow connection, the function can retry a few times.
+	///
+	/// - Parameter retry: **UInt** the number of time to retry.
+	/// - Parameter wait: **UInt32** the time to wait in-between retry.
+	///
 	/// - Returns: Optional **String**
 	///
-	func readString() throws -> String?
+	func readString(retry: UInt, wait: UInt32) throws -> String?
 	
 	///
 	/// Reads all available data into an Data object.
 	///
 	/// - Parameter data: **Data** object to contain read data.
+	/// - Parameter retry: **UInt** the number of time to retry.
+	/// - Parameter wait: **UInt32** the time to wait in-between retry.
 	///
 	/// - Returns: Integer representing the number of bytes read.
 	///
-	func read(into data: inout Data) throws -> Int
+	func read(into data: inout Data, retry: UInt, wait: UInt32) throws -> Int
 	
 	///
 	/// Reads all available data into an **NSMutableData** object.
 	///
 	/// - Parameter data: **NSMutableData** object to contain read data.
+	/// - Parameter retry: **UInt** the number of time to retry.
+	/// - Parameter wait: **UInt32** the time to wait in-between retry.
 	///
 	/// - Returns: Integer representing the number of bytes read.
 	///
-	func read(into data: NSMutableData) throws -> Int
+	func read(into data: NSMutableData, retry: UInt, wait: UInt32) throws -> Int
 }
 
 // MARK: Writer


### PR DESCRIPTION
Add a retry option with delay for reading through a socket.
Issue: #176
Idea from @Nathipha

## Description
The protocol for reading through a socket has been extended to handle a potential retry operation, with delay.
This should allow slow server to respond on time.

## Motivation and Context
This should fix the issue #176 

## How Has This Been Tested?
No real tests done, but existing behavior shouldn't change.
@nathipha could you give it a try with in your context?

## Checklist:
- [X] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [X] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
