### PR TITLE
Fix warnings due to improper exclusion; update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build
 .DS_Store
 xcuserdata/
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let libraryBuildInfo = BuildInfo(
         .target(
             name: "Socket",
             dependencies: [],
-            exclude: ["BlueSocket.xcodeproj", "BlueSocket.xcworkspace", "README.md", "Sources/Info.plist", "Sources/Socket.h"]
+            exclude: ["Info.plist", "Socket.h"]
         ),
         .testTarget(
             name: "SocketTests",


### PR DESCRIPTION
Fix warnings due to improper exclusion in Package.swift file.